### PR TITLE
feat: Implemented setTrace and logTrace.

### DIFF
--- a/src/malls/__main__.py
+++ b/src/malls/__main__.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import pathlib
+import socket
 import sys
 
 from . import __LOG_FORMAT__
@@ -11,6 +12,8 @@ def configure_argument_parser(parser: argparse.ArgumentParser, subparser: bool =
     """
     Configures the parser for usage with the MAL Language Server. If the parser is already used
     for other means (through `subparser` parameter), this simply adds a subparser.
+
+    Users must choose EITHER file I/O OR TCP socket mode (mutually exclusive).
     """
     if subparser:
         subparser = argparse.ArgumentParser("mal-ls", "MAL Language Server")
@@ -19,30 +22,46 @@ def configure_argument_parser(parser: argparse.ArgumentParser, subparser: bool =
     else:
         parser.description = "MAL Language Server"
 
+    # ---- Mutually Exclusive Group: File I/O vs. TCP Socket ----
+    mode_group = parser.add_mutually_exclusive_group(required=True)
+
     # File I/O
-    fileio = parser.add_argument_group("File I/O", "Use the server through ")
-    fileio.add_argument(
+    file_group = mode_group.add_argument_group("File I/O", "Use file-based communication")
+    file_group.add_argument(
         "-i",
         "--in",
         dest="in_file_path",
         type=pathlib.Path,
         help="Sets which (pseudo)file to use as input. Prioritized over --stdio.",
     )
-    fileio.add_argument(
+    file_group.add_argument(
         "-o",
         "--out",
         dest="out_file_path",
         type=pathlib.Path,
         help=("Sets which (pseudo)file to use as output. Prioritized over --stdio."),
     )
-    fileio.add_argument(
-        "--stdio",
-        action="store_true",
-        help=(
-            "Use stdio for --in and --out. Use in conjunction with --in/out to customize"
-            " only one of stdio."
-        ),
+
+    # TCP Socket Mode
+    tcp_group = mode_group.add_argument_group("TCP Socket", "Use TCP socket communication")
+    tcp_group.add_argument(
+        "--host",
+        type=str,
+        default="localhost",
+        dest="host",
+        help="Host to bind the TCP server to (default: localhost).",
     )
+    tcp_group.add_argument(
+        "-p",
+        "--port",
+        type=int,
+        default=8080,
+        dest="port",
+        help="Port to bind the TCP server to (default: 8080).",
+    )
+
+    mode_group.add_argument('--stdio', action='store_true', help="Use stdio")
+    mode_group.add_argument('--tcp', action='store_true', help="Use TCP mode")
 
     # Loggin
     logging = parser.add_argument_group("Logging", "Configure logging options")
@@ -71,6 +90,29 @@ def fileio(args: argparse.Namespace):
     out_file = open(args.out_file_path, "wb") if args.out_file_path else sys.stdout.buffer
     return in_file, out_file
 
+def uses_tcpsocket(args: argparse.Namespace) -> bool:
+    return bool(args.tcp or args.host or args.port)
+
+def tcpsocket(args: argparse.Namespace):
+    host = args.host if args.host else "localhost"
+    port = args.port if args.port else 8080
+
+    server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server_socket.bind((host, port))
+
+    # Listen for one incoming connection at a time
+    server_socket.listen(1)
+
+    # blocks until a client connects
+    conn, addr = server_socket.accept() 
+
+    # get file-like objects from the socket
+    # this allows your existing server to work with TCP sockets
+    in_stream = conn.makefile('rb')
+    out_stream = conn.makefile('wb')
+
+    return in_stream, out_stream
 
 def configure_logging(args: argparse.Namespace) -> None:
     root_logger = logging.root
@@ -107,6 +149,9 @@ def main(args: argparse.Namespace | None = None):
 
     if uses_fileio(args):
         i, o = fileio(args)
+        start_fileio_server(i, o)
+    elif uses_tcpsocket(args):
+        i, o = tcpsocket(args)
         start_fileio_server(i, o)
 
 

--- a/src/malls/mal_lsp.py
+++ b/src/malls/mal_lsp.py
@@ -72,6 +72,10 @@ class MALLSPServer(MethodDispatcher):
     def state(self) -> LifecycleFSM:
         return self.__lifecycle
 
+    @property
+    def traceValue(self) -> TraceValue:
+        return self.__trace_value
+
     # Helper function to change the traceValue.
     # Log an error if the traceValue is not recognized.
     def _change_trace_value(self, new_trace_value: str) -> None:

--- a/src/malls/mal_lsp.py
+++ b/src/malls/mal_lsp.py
@@ -51,7 +51,9 @@ class MALLSPServer(MethodDispatcher):
 
     # leave capabilities as dict for now, replace with explicit class/type later
     def capabilities(self, client_capabilities: dict | None = None):
-        capabilities = {}
+        capabilities = {
+            'positionEncoding': self.__encoding,
+        }
         log.debug("Server capabilities: %s", capabilities)
         return capabilities
 

--- a/src/malls/mal_lsp.py
+++ b/src/malls/mal_lsp.py
@@ -177,6 +177,16 @@ class MALLSPServer(MethodDispatcher):
         )
 
     def m_exit(self, **kwargs) -> None:
+        
+        # Example of notification message
+            
+        # Only notify if traces are on
+        if (self.traceValue != TraceValue.Off):
+            params = {'message':'Exiting language server'}
+            if self.traceValue == TraceValue.Verbose:
+                params['verbose'] = 'Verbose example'  # placeholder
+            self.__endpoint.notify("exit", params)
+
         log.info("Exiting language server.")
         self.__endpoint.shutdown()
         log.info("Endpoint shut down.")

--- a/src/malls/mal_lsp.py
+++ b/src/malls/mal_lsp.py
@@ -5,12 +5,17 @@ from pylsp_jsonrpc.dispatchers import MethodDispatcher
 from pylsp_jsonrpc.endpoint import Endpoint
 from pylsp_jsonrpc.streams import JsonRpcStreamReader, JsonRpcStreamWriter
 
-from .lsp.enums import ErrorCodes
+from .lsp.enums import ErrorCodes, TraceValue
 from .lsp.fsm import LifecycleFSM
 
 log = logging.getLogger(__name__)
 MAL_FILETYPES = (".mal",)
 
+class MALLSPEXCEPTION(Exception):
+    def __init__(self, code, message):
+        self.code = code
+        self.error_msg = message
+        super().__init__(f"Error {code}: {message}") 
 
 def start_fileio_server(in_file: typing.BinaryIO, out_file: typing.BinaryIO) -> None:
     log.info("Starting MAL IO language server.")
@@ -35,6 +40,9 @@ class MALLSPServer(MethodDispatcher):
 
         self.__encoding = "utf-16"
         self.__lifecycle = LifecycleClass()
+
+        # By default, the value is Off
+        self.__trace_value = TraceValue.Off
 
     def start(self) -> None:
         """Starts the language server."""
@@ -64,12 +72,42 @@ class MALLSPServer(MethodDispatcher):
     def state(self) -> LifecycleFSM:
         return self.__lifecycle
 
+    # Helper function to change the traceValue.
+    # Log an error if the traceValue is not recognized.
+    def _change_trace_value(self, new_trace_value: str) -> None:
+        match (new_trace_value):
+            case 'off':
+                self.__trace_value = TraceValue.Off
+            case 'messages':
+                self.__trace_value = TraceValue.Messages
+            case 'verbose':
+                self.__trace_value = TraceValue.Verbose
+            case _:
+                # TODO this should throw an error
+                error_msg = f'Unrecognized trace value: `{new_trace_value}`. Options are: `off`, `messages` and `verbose`.'
+                log.error(error_msg)
+                raise MALLSPEXCEPTION(ErrorCodes.InvalidParams, error_msg)
+
+        log.info(f"Updating trace value to: `{new_trace_value}`")
+
+    # This method is to be incrementally increased by adding
+    # processing capabilities for each of the initialize parameters
+    def _process_initialize_parameters(self, **kwargs):
+        if ('trace' in kwargs):
+            self._change_trace_value(kwargs['trace'])
+
     # leave capabilities and response as dict for now, replace with explicit class/type later
     def m_initialize(
         self, processId: int | None = None, rootUri: str | None = None, **kwargs
     ) -> dict:
         log.info("Initializing server with parameters: %s %s", processId, rootUri)
         log.debug("Defered server parameters: %s", kwargs)
+
+        if (kwargs):
+            try:
+                self._process_initialize_parameters(**kwargs)
+            except MALLSPEXCEPTION as e:
+                return self.__respond_with_error(e.error_msg, e.code)
 
         return {
             "capabilities": self.capabilities(kwargs.get("capabilities")),
@@ -92,6 +130,15 @@ class MALLSPServer(MethodDispatcher):
             "error": {
                 "code": error,
                 "message": message,
+            }
+        }
+
+    # TODO maybe join with __invalid_request_at_lifecycle
+    def __respond_with_error(self, error_msg: str, error_code: int) -> dict:
+        return {
+            "error": {
+                "code": error_code,
+                "message": error_msg,
             }
         }
 

--- a/src/malls/mal_lsp.py
+++ b/src/malls/mal_lsp.py
@@ -1,7 +1,7 @@
 import logging
 import typing
 
-from pylsp_jsonrpc.dispatchers import MethodDispatcher
+from pylsp_jsonrpc.dispatchers import MethodDispatcher, _method_to_string
 from pylsp_jsonrpc.endpoint import Endpoint
 from pylsp_jsonrpc.streams import JsonRpcStreamReader, JsonRpcStreamWriter
 
@@ -62,7 +62,7 @@ class MALLSPServer(MethodDispatcher):
         else:
             item = "invalid_request_at_" + self.__lifecycle.current_state
         try:
-            return super().__getitem__(item)
+            return super().__getitem__(_method_to_string(item))
         except Exception as e:
             # Log and rethrow, cannot do anything if the method isn't known
             log.error(f"Error attempting to reach method `{item}`:", str(e))
@@ -83,7 +83,6 @@ class MALLSPServer(MethodDispatcher):
             case 'verbose':
                 self.__trace_value = TraceValue.Verbose
             case _:
-                # TODO this should throw an error
                 error_msg = f'Unrecognized trace value: `{new_trace_value}`. Options are: `off`, `messages` and `verbose`.'
                 log.error(error_msg)
                 raise MALLSPEXCEPTION(ErrorCodes.InvalidParams, error_msg)
@@ -183,3 +182,13 @@ class MALLSPServer(MethodDispatcher):
         if self.__jsonrpc_stream_writer:
             self.__jsonrpc_stream_writer.close()
             log.info("JSON RPC writer closed.")
+
+    def m___set_trace(self, **kwargs):
+        # For a notification, there is no response,
+        # even if there is an error, so the function
+        # shall just return
+        if ('value' in kwargs):
+            try:
+                self._change_trace_value(kwargs['value'])
+            finally:
+                return

--- a/src/malls/mal_lsp.py
+++ b/src/malls/mal_lsp.py
@@ -5,7 +5,7 @@ from pylsp_jsonrpc.dispatchers import MethodDispatcher, _method_to_string
 from pylsp_jsonrpc.endpoint import Endpoint
 from pylsp_jsonrpc.streams import JsonRpcStreamReader, JsonRpcStreamWriter
 
-from .lsp.enums import ErrorCodes, TraceValue
+from .lsp.enums import ErrorCodes, TraceValue, PositionEncodingKind
 from .lsp.fsm import LifecycleFSM
 
 log = logging.getLogger(__name__)
@@ -49,8 +49,33 @@ class MALLSPServer(MethodDispatcher):
         log.info("Starting MAL LSP language server.")
         self.__jsonrpc_stream_reader.listen(self.__endpoint.consume)
 
+    def _process_encoding(self, encodings: PositionEncodingKind):
+        # According to documentation, if utf-16 is missing, the server should
+        # assume that this encoding is supported and should be used.
+        #
+        # Therefore, only if the UTF-16 is present can we choose another
+        # encoding
+        #
+        # TODO decide which encoding to choose
+        if (PositionEncodingKind.UTF16 in encodings):
+            # TODO change encoding
+            # self.__encoding = ???
+            pass
+
+    # Auxiliary method to process and react to client capabilities
+    def _process_client_capabilities(self, capabilities: dict):
+        if ('general' in client_capabilities):
+            general = client_capabilities['general']
+            if ('positionEncodings' in general):
+                self._process_encoding(general['positionEncodings'])
+        return 
+
     # leave capabilities as dict for now, replace with explicit class/type later
     def capabilities(self, client_capabilities: dict | None = None):
+
+        if client_capabilities:
+            self._process_client_capabilities(capabilities)
+
         capabilities = {
             'positionEncoding': self.__encoding,
         }
@@ -108,16 +133,16 @@ class MALLSPServer(MethodDispatcher):
         log.info("Initializing server with parameters: %s %s", processId, rootUri)
         log.debug("Defered server parameters: %s", kwargs)
 
-        if (kwargs):
-            try:
+        try:
+            if (kwargs):
                 self._process_initialize_parameters(**kwargs)
-            except MALLSPEXCEPTION as e:
-                return self.__respond_with_error(e.error_msg, e.code)
 
-        return {
-            "capabilities": self.capabilities(kwargs.get("capabilities")),
-            "serverInfo": {"name": "mal-ls"},
-        }
+            return {
+                "capabilities": self.capabilities(kwargs.get("capabilities")),
+                "serverInfo": {"name": "mal-ls"},
+            }
+        except MALLSPEXCEPTION as e:
+            return self.__respond_with_error(e.error_msg,e.code)
 
     def m_initialized(self, *args, **kwargs) -> None:
         log.debug("Client initialized with parameters %s %s", args, kwargs)

--- a/tests/features/test_encoding_capability.py
+++ b/tests/features/test_encoding_capability.py
@@ -1,0 +1,17 @@
+import typing
+from malls.lsp.enums import PositionEncodingKind
+from ..util import get_lsp_json, SteppedBytesIO, server_output
+
+def test_encoding_capability_simple(
+        encoding_capability_check_in: typing.BinaryIO):
+    output, ls, *_ = server_output(encoding_capability_check_in)
+
+    # the test and server share the same buffer,
+    # so we must reset the cursor
+    output.seek(0)
+
+    response = get_lsp_json(output)
+
+    # Ensure encoding defaults to UTF16 if not specified by the client
+    # https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#clientCapabilities
+    assert response['result']['capabilities']['positionEncoding'] == PositionEncodingKind.UTF16

--- a/tests/features/test_trace.py
+++ b/tests/features/test_trace.py
@@ -3,7 +3,7 @@ import io
 import logging
 import typing
 
-from malls.lsp.enums import ErrorCodes
+from malls.lsp.enums import ErrorCodes, TraceValue
 from malls.lsp.fsm import LifecycleState
 from malls.mal_lsp import MALLSPServer
 
@@ -69,3 +69,22 @@ def test_wrong_trace_value_in_initialization(
     assert response['error']['code'] == ErrorCodes.InvalidParams
 
     output.close()
+
+def test_set_trace_correctly(
+        set_trace_value_in: typing.BinaryIO):
+    output, ls, *_ = server_output(set_trace_value_in)
+
+    # ensure ls has trace value correctly set
+    assert ls.traceValue == TraceValue.Verbose
+
+    output.close()
+
+def test_set_trace_incorrectly(
+        set_wrong_trace_value_in: typing.BinaryIO):
+    output, ls, *_ = server_output(set_wrong_trace_value_in)
+
+    # ensure ls has trace value correctly set
+    assert ls.traceValue == TraceValue.Off
+
+    output.close()
+

--- a/tests/features/test_trace.py
+++ b/tests/features/test_trace.py
@@ -1,0 +1,71 @@
+import asyncio
+import io
+import logging
+import typing
+
+from malls.lsp.enums import ErrorCodes
+from malls.lsp.fsm import LifecycleState
+from malls.mal_lsp import MALLSPServer
+
+from ..util import get_lsp_json
+
+log = logging.getLogger(__name__)
+
+# wait for most 5s (arbitrary)
+MAX_TIMEOUT=2
+
+class SteppedBytesIO(io.BytesIO):
+    """
+    SteppedBytesIO provide a way to stop the closing of the IO N-1 times, closing on the Nth time.
+    """
+    def __init__(self, initial_bytes: bytes = b'', steps: int = 1):
+        self.steps = steps
+
+    def close(self):
+        if self.steps <= 0:
+            super(io.BytesIO, self).close()
+        else:
+            self.steps -= 1
+
+# TODO: create fake endpoint class (or similar) so the input can be stepped
+
+# https://github.com/python-lsp/python-lsp-server/blob/develop/pylsp/python_lsp.py#L58
+def server_output(
+        input: typing.BinaryIO,
+        timeout: float | None = MAX_TIMEOUT) -> typing.Tuple[typing.BinaryIO, MALLSPServer, TimeoutError | None]:
+    intermediary = SteppedBytesIO()
+    ls = MALLSPServer(input, intermediary)
+    time_out_err = None
+
+    async def run_server():
+        ls.start()
+
+    try:
+        server_future = run_server()
+        asyncio.run(asyncio.wait_for(server_future, 1))
+    except TimeoutError as e:
+        ls.m_exit()
+        time_out_err = e
+    except Exception as e:
+        intermediary.close()
+        raise e
+
+    return intermediary, ls, time_out_err
+
+def test_wrong_trace_value_in_initialization(
+        wrong_trace_value_in: typing.BinaryIO):
+    output, ls, *_ = server_output(wrong_trace_value_in)
+
+    # the test and server share the same buffer,
+    # so we must reset the cursor
+    output.seek(0)
+
+    response = get_lsp_json(output)
+
+    # Ensure there is an error on the response corresponding to invalid
+    # parameter, since "traceValue" is wrong
+    assert "error" in response
+    assert 'code' in response['error']
+    assert response['error']['code'] == ErrorCodes.InvalidParams
+
+    output.close()

--- a/tests/features/test_trace.py
+++ b/tests/features/test_trace.py
@@ -7,50 +7,10 @@ from malls.lsp.enums import ErrorCodes, TraceValue
 from malls.lsp.fsm import LifecycleState
 from malls.mal_lsp import MALLSPServer
 
-from ..util import get_lsp_json
+from ..util import get_lsp_json, SteppedBytesIO, server_output
 
 log = logging.getLogger(__name__)
 
-# wait for most 5s (arbitrary)
-MAX_TIMEOUT=2
-
-class SteppedBytesIO(io.BytesIO):
-    """
-    SteppedBytesIO provide a way to stop the closing of the IO N-1 times, closing on the Nth time.
-    """
-    def __init__(self, initial_bytes: bytes = b'', steps: int = 1):
-        self.steps = steps
-
-    def close(self):
-        if self.steps <= 0:
-            super(io.BytesIO, self).close()
-        else:
-            self.steps -= 1
-
-# TODO: create fake endpoint class (or similar) so the input can be stepped
-
-# https://github.com/python-lsp/python-lsp-server/blob/develop/pylsp/python_lsp.py#L58
-def server_output(
-        input: typing.BinaryIO,
-        timeout: float | None = MAX_TIMEOUT) -> typing.Tuple[typing.BinaryIO, MALLSPServer, TimeoutError | None]:
-    intermediary = SteppedBytesIO()
-    ls = MALLSPServer(input, intermediary)
-    time_out_err = None
-
-    async def run_server():
-        ls.start()
-
-    try:
-        server_future = run_server()
-        asyncio.run(asyncio.wait_for(server_future, 1))
-    except TimeoutError as e:
-        ls.m_exit()
-        time_out_err = e
-    except Exception as e:
-        intermediary.close()
-        raise e
-
-    return intermediary, ls, time_out_err
 
 def test_wrong_trace_value_in_initialization(
         wrong_trace_value_in: typing.BinaryIO):

--- a/tests/features/test_trace.py
+++ b/tests/features/test_trace.py
@@ -88,3 +88,61 @@ def test_set_trace_incorrectly(
 
     output.close()
 
+def test_log_trace_messages(
+        log_trace_messages_in: typing.BinaryIO):
+    output, ls, *_ = server_output(log_trace_messages_in)
+
+    # the test and server share the same buffer,
+    # so we must reset the cursor
+    output.seek(0)
+
+    # Skip to last message 
+    response = get_lsp_json(output)
+    response = get_lsp_json(output)
+    response = get_lsp_json(output)
+
+    assert "method" in response
+    assert "exit" == response['method']
+    assert "params" in response
+    assert 'message' in response['params']
+    assert 'verbose' not in response['params']
+
+    output.close()
+
+def test_log_trace_verbose(
+        log_trace_verbose_in: typing.BinaryIO):
+    output, ls, *_ = server_output(log_trace_verbose_in)
+
+    # the test and server share the same buffer,
+    # so we must reset the cursor
+    output.seek(0)
+
+    # Skip to last message 
+    response = get_lsp_json(output)
+    response = get_lsp_json(output)
+    response = get_lsp_json(output)
+
+    assert "method" in response
+    assert "exit" == response['method']
+    assert "params" in response
+    assert 'message' in response['params']
+    assert 'verbose' in response['params']
+
+    output.close()
+
+def test_log_trace_off(
+        log_trace_off_in: typing.BinaryIO):
+    output, ls, *_ = server_output(log_trace_off_in)
+
+    # the test and server share the same buffer,
+    # so we must reset the cursor
+    output.seek(0)
+
+    # Ensure no notification about exit was sent
+    assert b'exit' not in output.getvalue()
+
+    output.close()
+
+
+
+

--- a/tests/fixtures/log_trace_messages.in.lsp
+++ b/tests/fixtures/log_trace_messages.in.lsp
@@ -1,0 +1,15 @@
+Content-Length: 72
+
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"trace":"off"}}
+Content-Length: 41
+
+{"jsonrpc":"2.0","method":"initialized"}
+Content-Length: 71
+
+{"jsonrpc": "2.0","method":"$/setTrace","params":{"value":"messages"}}
+Content-Length: 45
+
+{"jsonrpc":"2.0","id":2,"method":"shutdown"}
+Content-Length: 34
+
+{"jsonrpc":"2.0","method":"exit"}

--- a/tests/fixtures/log_trace_off.in.lsp
+++ b/tests/fixtures/log_trace_off.in.lsp
@@ -1,0 +1,12 @@
+Content-Length: 72
+
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"trace":"off"}}
+Content-Length: 41
+
+{"jsonrpc":"2.0","method":"initialized"}
+Content-Length: 45
+
+{"jsonrpc":"2.0","id":2,"method":"shutdown"}
+Content-Length: 34
+
+{"jsonrpc":"2.0","method":"exit"}

--- a/tests/fixtures/log_trace_verbose.in.lsp
+++ b/tests/fixtures/log_trace_verbose.in.lsp
@@ -1,0 +1,15 @@
+Content-Length: 72
+
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"trace":"off"}}
+Content-Length: 41
+
+{"jsonrpc":"2.0","method":"initialized"}
+Content-Length: 70
+
+{"jsonrpc": "2.0","method":"$/setTrace","params":{"value":"verbose"}}
+Content-Length: 45
+
+{"jsonrpc":"2.0","id":2,"method":"shutdown"}
+Content-Length: 34
+
+{"jsonrpc":"2.0","method":"exit"}

--- a/tests/fixtures/set_trace_value.in.lsp
+++ b/tests/fixtures/set_trace_value.in.lsp
@@ -1,0 +1,15 @@
+Content-Length: 72
+
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"trace":"off"}}
+Content-Length: 41
+
+{"jsonrpc":"2.0","method":"initialized"}
+Content-Length: 70
+
+{"jsonrpc": "2.0","method":"$/setTrace","params":{"value":"verbose"}}
+Content-Length: 45
+
+{"jsonrpc":"2.0","id":2,"method":"shutdown"}
+Content-Length: 34
+
+{"jsonrpc":"2.0","method":"exit"}

--- a/tests/fixtures/set_wrong_trace_value.in.lsp
+++ b/tests/fixtures/set_wrong_trace_value.in.lsp
@@ -1,0 +1,15 @@
+Content-Length: 72
+
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"trace":"off"}}
+Content-Length: 41
+
+{"jsonrpc":"2.0","method":"initialized"}
+Content-Length: 70
+
+{"jsonrpc": "2.0","method":"$/setTrace","params":{"value":"vxrbxsx"}}
+Content-Length: 45
+
+{"jsonrpc":"2.0","id":2,"method":"shutdown"}
+Content-Length: 34
+
+{"jsonrpc":"2.0","method":"exit"}

--- a/tests/fixtures/wrong_trace_value.in.lsp
+++ b/tests/fixtures/wrong_trace_value.in.lsp
@@ -1,0 +1,12 @@
+Content-Length: 72
+
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"trace":"odf"}}
+Content-Length: 41
+
+{"jsonrpc":"2.0","method":"initialized"}
+Content-Length: 45
+
+{"jsonrpc":"2.0","id":2,"method":"shutdown"}
+Content-Length: 34
+
+{"jsonrpc":"2.0","method":"exit"}

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,5 +1,7 @@
+import asyncio
 import io
 import json
+import typing
 
 from pylsp_jsonrpc.endpoint import Endpoint
 from pylsp_jsonrpc.exceptions import JsonRpcException
@@ -46,3 +48,44 @@ class FakeLanguageServer(MALLSPServer):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("EndpointClass", FakeEndpoint)
         super().__init__(*args, **kwargs)
+
+# wait for most 5s (arbitrary)
+MAX_TIMEOUT=2
+
+class SteppedBytesIO(io.BytesIO):
+    """
+    SteppedBytesIO provide a way to stop the closing of the IO N-1 times, closing on the Nth time.
+    """
+    def __init__(self, initial_bytes: bytes = b'', steps: int = 1):
+        self.steps = steps
+
+    def close(self):
+        if self.steps <= 0:
+            super(io.BytesIO, self).close()
+        else:
+            self.steps -= 1
+
+# TODO: create fake endpoint class (or similar) so the input can be stepped
+
+# https://github.com/python-lsp/python-lsp-server/blob/develop/pylsp/python_lsp.py#L58
+def server_output(
+        input: typing.BinaryIO,
+        timeout: float | None = MAX_TIMEOUT) -> typing.Tuple[typing.BinaryIO, MALLSPServer, TimeoutError | None]:
+    intermediary = SteppedBytesIO()
+    ls = MALLSPServer(input, intermediary)
+    time_out_err = None
+
+    async def run_server():
+        ls.start()
+
+    try:
+        server_future = run_server()
+        asyncio.run(asyncio.wait_for(server_future, 1))
+    except TimeoutError as e:
+        ls.m_exit()
+        time_out_err = e
+    except Exception as e:
+        intermediary.close()
+        raise e
+
+    return intermediary, ls, time_out_err


### PR DESCRIPTION
# `setTrace` and `logTrace`

Implemented the `setTrace` to allow the client to choose the correct level of logging. This can be done via a notification or when starting the server (the default value is `off`).

However, the `logTrace` involves notifications which should be discussed, to agree when to send and what should be included in messages and in verbosity.

Tests were included for all features and methods.

Addresses #5 (partial fix)
Fixes #9 

# Minimal capability set

The only capability that the server could announce thus far was the encoding. Therefore, this capability is now announced. However, it must still be decided which encoding is chosen given a choice between utf-8, utf-16 and utf-32

Addresses #8 (partial fix)

# TCP Communication

A user can now specify `--stdio` to use files or `--tcp` to use a socket. This way, the server can either use files or TCP to communicate with the client. 

Fixes #2 