### PR TITLE
feat: Package distribution workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+
+name: Language Server Tests
+
+on:
+  push:
+    tags: ["*"]
+  
+jobs:
+  language-server-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup environment
+        # Actions use only the folder name (with an action.yml inside)
+        # https://github.com/orgs/community/discussions/26245#discussioncomment-5962450
+        # https://docs.github.com/en/actions/tutorials/creating-a-composite-action#creating-an-action-metadata-file
+        uses: ./.github/actions/py-setup
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish package
+        run: uv publish
+        secrets:
+          UV_PUBLISH_TOKEN: ${{secrets.PYPI_API_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
 
-name: Language Server Tests
+name: Language Server Package Distribution
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -42,3 +42,9 @@ Other start-up arguments, namely related to logging, can be found using `uv run 
     ```
     > [!NOTE]
     > Tested for NeoVim v0.11.1
+
+## CI/CD
+
+Packages are published via UV on ubuntu to PyPI on tags pushed to the repository.
+
+Tests are ran with pytest and pytest-xdist on ubuntu and macos. Additionally formatting and linting checks are ran with ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "malls"
 version = "0.1.0"
 description = "Language server for MAL"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.11"
 
 authors = [{ name = "Tobiky", email = "me@tobiky.dev" }]
 urls = { github = "https://github.com/Tobiky/mal-ls" }


### PR DESCRIPTION
Adds a workflow to distribute the package to PyPI via the UV publish command. PyPI has trusted publishers so the token procedure isn't exactly necessary, however it's a familiar workflow and it's easier to remove than to add back in so its used as a base.

Closes #27 