### PR TITLE
feat: Reduce CI trigger scope

### DIFF
--- a/.github/workflows/ls.yml
+++ b/.github/workflows/ls.yml
@@ -3,6 +3,11 @@ name: Language Server Tests
 on:
   pull_request:
     branches: [ "master" ]
+    paths:
+      - pyproject.toml
+      - uv.lock
+      - src/**
+      - tests/**
   
 jobs:
   language-server-tests:


### PR DESCRIPTION
Reduces the CI trigger scope by adding a path filter of `pyproject.toml`, `uv.lock`, `src/`, and `tests/`.

Closes #37
