### PR TITLE
feat: Find comments for symbol function

### DIFF
--- a/src/malls/ts/utils.py
+++ b/src/malls/ts/utils.py
@@ -105,6 +105,14 @@ ERRORS_QUERY = Query(
 )
 
 
+COMMENTS_QUERY = Query(
+    MAL_LANGUAGE,
+    """
+    ((comment) @comment_node)*
+    """,
+)
+
+
 def find_variable_query(variable_name: str):
     query = Query(
         MAL_LANGUAGE,
@@ -1335,3 +1343,60 @@ def find_meta_comment_function(
         # terminate if there are no more parents
         if node is None:
             return []
+
+
+def find_comments_function(
+    node: Node, symbol: str, document_uri: str = "", storage: dict = {}
+) -> list:
+    """
+    Given a node and a symbol, this function will find the comments
+    associated to that symbol. Comments are considered to be associated
+    with a symbol if they appear in consecutive lines above the symbol.
+
+    E.g.:
+        // but not this
+
+        // this as well
+        // this comment is connected
+        let myVar = ...
+        // technically this *could* be connected to above but its a potentially complex scenario
+        // so only count it towards the node below, if there is one
+
+
+    The easiest way to do this is to find all comments in the file and only keep those
+    which appear in consecutive lines above the symbol.
+    """
+
+    start_row = node.start_point.row
+
+    # find comments
+    captures = run_query(storage[document_uri].tree.root_node, COMMENTS_QUERY)
+    if not captures:
+        return []  # there are no comments
+
+    # sort captures by row
+    sorted_comments = sorted(captures["comment_node"], key=lambda item: item.start_point.row)
+
+    comments = [sorted_comments[0].text]
+    previous_row = sorted_comments[0].end_point.row
+
+    for comment_node in sorted_comments[1:]:
+        current_row = comment_node.start_point.row
+
+        # if we have exceeded the row the symbol is in,
+        # we return what we have (as long as they are in
+        # consecutive rows)
+        if current_row > start_row:
+            break
+
+        # if the comment is in a consecutive row,
+        # we keep it
+        if current_row == previous_row + 1:
+            comments.append(comment_node.text)
+            previous_row = current_row  # update row
+        else:
+            # otherwise, restart the count
+            comments = [comment_node.text]
+            previous_row = comment_node.end_point.row
+
+    return comments if previous_row == start_row - 1 else []

--- a/src/malls/ts/utils.py
+++ b/src/malls/ts/utils.py
@@ -1376,7 +1376,7 @@ def find_comments_function(
 
     # sort captures by row
     sorted_comments = sorted(
-        [item for item in captures["comment_node"] if item.start_point.row < start_row],
+        filter(lambda item: item.start_point.row < start_row, captures["comment_node"]),
         key=lambda item: item.start_point.row,
     )
 

--- a/src/malls/ts/utils.py
+++ b/src/malls/ts/utils.py
@@ -1375,19 +1375,15 @@ def find_comments_function(
         return []  # there are no comments
 
     # sort captures by row
-    sorted_comments = sorted(captures["comment_node"], key=lambda item: item.start_point.row)
+    sorted_comments = sorted([
+        item for item in captures["comment_node"] if item.start_point.row < start_row
+    ], key=lambda item: item.start_point.row)
 
     comments = [sorted_comments[0].text]
     previous_row = sorted_comments[0].end_point.row
 
     for comment_node in sorted_comments[1:]:
         current_row = comment_node.start_point.row
-
-        # if we have exceeded the row the symbol is in,
-        # we return what we have (as long as they are in
-        # consecutive rows)
-        if current_row > start_row:
-            break
 
         # if the comment is in a consecutive row,
         # we keep it

--- a/src/malls/ts/utils.py
+++ b/src/malls/ts/utils.py
@@ -1375,9 +1375,10 @@ def find_comments_function(
         return []  # there are no comments
 
     # sort captures by row
-    sorted_comments = sorted([
-        item for item in captures["comment_node"] if item.start_point.row < start_row
-    ], key=lambda item: item.start_point.row)
+    sorted_comments = sorted(
+        [item for item in captures["comment_node"] if item.start_point.row < start_row],
+        key=lambda item: item.start_point.row,
+    )
 
     comments = [sorted_comments[0].text]
     previous_row = sorted_comments[0].end_point.row

--- a/tests/fixtures/mal/find_comments_for_symbol_function.mal
+++ b/tests/fixtures/mal/find_comments_for_symbol_function.mal
@@ -1,7 +1,15 @@
 #id: "org.mal-lang.testAnalyzer"
 #version:"0.0.0"
 
+// should not appear
+/*
+ * SHOULD NOT APPEAR
+ */
+
+// category comment
 category Example {
+
+    // should not appear
 
     // asset comment 1
     // asset comment 2
@@ -10,6 +18,10 @@ category Example {
         | compromise
         -> b.compromise
     }
+
+    /*
+     * SHOULD NOT APPEAR
+     */
 
     /* 
      * MULTI-LINE COMMENT
@@ -22,6 +34,11 @@ category Example {
         & attack
     }
 
+    /* 
+     * SHOULD NOT APPEAR
+     */
+    // should not appear
+
     // asset3 comment
     asset
     Asset3 { }
@@ -32,6 +49,9 @@ category Example {
 }
 associations 
 {
+    // should not appear
+    // should not appear
+
     // association comment
     Asset1 [a] * <-- L --> * [c] Asset2
 }

--- a/tests/fixtures/mal/find_comments_for_symbol_function.mal
+++ b/tests/fixtures/mal/find_comments_for_symbol_function.mal
@@ -1,0 +1,37 @@
+#id: "org.mal-lang.testAnalyzer"
+#version:"0.0.0"
+
+category Example {
+
+    // asset comment 1
+    // asset comment 2
+    asset Asset1 
+    {
+        | compromise
+        -> b.compromise
+    }
+
+    /* 
+     * MULTI-LINE COMMENT
+     */ 
+    // followed by single comment
+    asset Asset2 
+    {
+        | compromise
+        // attack_step comment
+        & attack
+    }
+
+    // asset3 comment
+    asset
+    Asset3 { }
+
+    asset
+    // asset4 comment
+    Asset4 { }
+}
+associations 
+{
+    // association comment
+    Asset1 [a] * <-- L --> * [c] Asset2
+}

--- a/tests/unit/test_find_comments_for_symbol_function.py
+++ b/tests/unit/test_find_comments_for_symbol_function.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+import pytest
+import tree_sitter_mal as ts_mal
+from tree_sitter import Language, Parser
+
+from malls.lsp.classes import Document
+from malls.lsp.utils import recursive_parsing
+from malls.ts.utils import INCLUDED_FILES_QUERY, find_comments_function, run_query
+
+MAL_LANGUAGE = Language(ts_mal.language())
+PARSER = Parser(MAL_LANGUAGE)
+FILE_PATH = str(Path(__file__).parent.parent.resolve()) + "/fixtures/mal/"
+
+parameters = [
+    ((7, 12), [b"// asset comment 1", b"// asset comment 2"]),
+    ((17, 12), [b"/* \n     * MULTI-LINE COMMENT\n     */", b"// followed by single comment"]),
+    ((21, 12), [b"// attack_step comment"]),
+    ((26, 8), []),
+    ((30, 6), [b"// asset4 comment"]),
+    ((35, 21), [b"// association comment"]),
+]
+
+
+@pytest.mark.parametrize(
+    "point,comments",
+    parameters,
+)
+def test_find_comments_for_symbol_function(mal_find_comments_for_symbol_function, point, comments):
+    # build the storage (mimicks the file parsing in the server)
+    storage = {}
+
+    doc_uri = FILE_PATH + "find_comments_for_symbol_function.mal"
+    source_encoded = mal_find_comments_for_symbol_function.read()
+    tree = PARSER.parse(source_encoded)
+
+    storage[doc_uri] = Document(tree, source_encoded, doc_uri)
+
+    # obtain the included files
+    root_node = tree.root_node
+
+    captures = run_query(root_node, INCLUDED_FILES_QUERY)
+    if "file_name" in captures:
+        recursive_parsing(FILE_PATH, captures["file_name"], storage, doc_uri, [])
+
+    ###################################
+
+    # get the node
+    cursor = tree.walk()
+    while cursor.goto_first_child_for_point(point) is not None:
+        continue
+
+    # confirm it's an identifier
+    assert cursor.node.type == "identifier"
+
+    # we use sets to ensure order does not matter
+    returned_comments = find_comments_function(cursor.node, cursor.node.text, doc_uri, storage)
+
+    assert set(returned_comments) == set(comments)

--- a/tests/unit/test_find_comments_for_symbol_function.py
+++ b/tests/unit/test_find_comments_for_symbol_function.py
@@ -13,12 +13,13 @@ PARSER = Parser(MAL_LANGUAGE)
 FILE_PATH = str(Path(__file__).parent.parent.resolve()) + "/fixtures/mal/"
 
 parameters = [
-    ((7, 12), [b"// asset comment 1", b"// asset comment 2"]),
-    ((17, 12), [b"/* \n     * MULTI-LINE COMMENT\n     */", b"// followed by single comment"]),
-    ((21, 12), [b"// attack_step comment"]),
-    ((26, 8), []),
-    ((30, 6), [b"// asset4 comment"]),
-    ((35, 21), [b"// association comment"]),
+    ((9, 13), [b"// category comment"]),
+    ((15, 12), [b"// asset comment 1", b"// asset comment 2"]),
+    ((29, 12), [b"/* \n     * MULTI-LINE COMMENT\n     */", b"// followed by single comment"]),
+    ((33, 12), [b"// attack_step comment"]),
+    ((43, 8), []),
+    ((47, 6), [b"// asset4 comment"]),
+    ((55, 21), [b"// association comment"]),
 ]
 
 


### PR DESCRIPTION
This PR creates a function that, given a node and a symbol, finds the comments associated with the symbol. A corresponding test suite was also added.

As mentioned in the issue, the considered comments are those that appear in consecutive lines above the node. For this, all comments were captured and only those that meet the criteria are kept.

Closes: #24 